### PR TITLE
fixes item stacking in Build Order and adjusts style

### DIFF
--- a/react/src/components/summoner/BuildOrder.tsx
+++ b/react/src/components/summoner/BuildOrder.tsx
@@ -350,8 +350,8 @@ function BuildOrder(props: {
                                     width: 15,
                                     background: 'white',
                                     color: 'black',
-				    opacity: '0.70',
-				    textAlign: 'center',
+                                    opacity: '0.70',
+                                    textAlign: 'center',
                                     fontSize: '75%',
                                     borderRadius: 5,
                                   }}


### PR DESCRIPTION
Removed ${event.timestamp} from the key, so purchases of the same item in the same group are stacked. Potentially changes the order that the items are listed within the group.

Style adjusted to make the number a bit smaller and makes the background slightly transparent.

Style before: 
![css-before-ivern](https://user-images.githubusercontent.com/13354874/136621526-c8f0c80f-cdc4-4376-8c72-261d8eb717ba.PNG)

Style after:
![css-after-ivern](https://user-images.githubusercontent.com/13354874/136621566-2db42046-df90-416e-a249-ad3c1b5e0e6f.PNG)